### PR TITLE
enable idled

### DIFF
--- a/cyrus-imapd-tester/Dockerfile
+++ b/cyrus-imapd-tester/Dockerfile
@@ -13,6 +13,7 @@ RUN sed -ri \
     && sed -ri \
     -e 's!^  pop3!#  pop3!g' \
     -e 's!^  http!#  http!g' \
+    -e 's!^#  idled!  idled!g' \
     /etc/cyrus.conf
 
 RUN postconf \


### PR DESCRIPTION
I was trying to use cyrus-imapd-tester image to test projects that use [Delta Chat](https://github.com/deltachat/) but IMAP IDLE is required and idled daemon was not enabled in the cyrus config